### PR TITLE
Add datagovsg_api and fix packaging issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Currently supported datasets are:
 
 * [Onemap](http://github.com/ruiwen/onemap)
 * [NEA](http://github.com/davidchua/nea_api)
+* [Developers.data.gov.sg](https://github.com/half0wl/datagovsg_api)
 
 To use, all you need to do is to
 
@@ -17,6 +18,7 @@ $ pip install singapore
 # python
 from singapore import onemap
 from singapore import nea_api
+from singapore import datagovsg_api
 ```
 
 #### OneMap
@@ -64,6 +66,24 @@ OrderedDict([('channel', OrderedDict([('title', 'PM2.5 Update'), ('source', 'Air
 ```
 
 For more information, check out the main [README](https://github.com/davidchua/nea_api)
+
+#### datagovsg_api
+
+Sample:
+
+```python
+import datagovsg_api
+
+sg_data = datagovsg_api.AllAPI('API_KEY')
+
+# Get taxi availability
+print(sg_data.taxi_availability().json())
+
+# Get 2-hour weather forecast
+print(sg_data.weather_forecast(duration='2-hour').json())
+```
+
+For more information, check out the main [README](https://github.com/half0wl/datagovsg_api)
 
 #### TODO
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ setup(
   version = '0.0.1.1',
   install_requires=[
         'xmltodict','requests',
-        'onemap', 'nea_api'
+        'onemap', 'nea_api',
+        'datagovsg_api'
   ],
   description = "A unified Python API Wrapper for Data.gov.sg services",
   author = 'CodeSG',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
   name = 'singapore',
-  packages = ['singapore'],
+  packages = ['singapore', 'singapore.onemap', 'singapore.nea_api', 'singapore.datagovsg_api'],
   version = '0.0.1.1',
   install_requires=[
         'xmltodict','requests',

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,30 @@
-import os, sys
 from distutils.core import setup
 from distutils.command.install import install as _install
 from setuptools import setup
 
 
 setup(
-  name = 'singapore',
-  packages = ['singapore', 'singapore.onemap', 'singapore.nea_api', 'singapore.datagovsg_api'],
-  version = '0.0.1.1',
-  install_requires=[
-        'xmltodict','requests',
-        'onemap', 'nea_api',
+    name='singapore',
+    packages=[
+        'singapore',
+        'singapore.onemap',
+        'singapore.nea_api',
+        'singapore.datagovsg_api'
+    ],
+    version='0.0.1.1',
+    install_requires=[
+        'xmltodict',
+        'requests',
+        'onemap',
+        'nea_api',
         'datagovsg_api'
-  ],
-  description = "A unified Python API Wrapper for Data.gov.sg services",
-  author = 'CodeSG',
-  author_email = 'zhchua@gmail.com',
-  url = 'https://github.com/codelah/singapore',
-  keywords = ['data.gov.sg', 'python', 'wrapper', 'psi', 'nea', 'onemap', 'singapore'],
-  classifiers = [],
+    ],
+    description='A unified Python API Wrapper for Data.gov.sg services',
+    author='CodeSG',
+    author_email='zhchua@gmail.com',
+    url='https://github.com/codelah/singapore',
+    keywords=[
+        'data.gov.sg', 'python', 'wrapper', 'psi', 'nea', 'onemap', 'singapore'
+    ],
+    classifiers=[],
 )

--- a/singapore/__init__.py
+++ b/singapore/__init__.py
@@ -1,7 +1,0 @@
-
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)
-
-print __path__
-print "Singapore Hello"

--- a/singapore/datagovsg_api/__init__.py
+++ b/singapore/datagovsg_api/__init__.py
@@ -1,0 +1,1 @@
+from datagovsg_api import *


### PR DESCRIPTION
Currently, installing the `singapore` package doesn't install the subpackages into `site-packages/`, so the subpackages can't be imported:

```
$ pip install --no-cache-dir singapore
$ python
Python 2.7.13 (default, Apr  4 2017, 08:47:57)
[GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from singapore import nea_api
['/Users/half0wl/Workspace/testing/.venv-py2/lib/python2.7/site-packages/singapore']
Singapore Hello
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name nea_api
>>> from singapore import onemap
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name onemap
```

This PR should fix it by including the subpackages in `setup.py` and removing the need for any code to be in `singapore/__init__.py` (and also Py3 support).

```
$ python setup.py sdist bdist_wheel --universal
$ pip install --no-cache-dir dist/singapore-0.0.1.1-py2.py3-none-any.whl
$ python
Python 2.7.13 (default, Apr  4 2017, 08:47:57)
[GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from singapore import nea_api
>>> from singapore import onemap
>>> from singapore import datagovsg_api
>>>
```

